### PR TITLE
Fix code coverage report

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -10,6 +10,7 @@ COV = coverage.coverage(
     omit=[
         'tests/*',
         '*/test_*.py',
+        '*/tests/*',
     ]
 )
 COV.start()


### PR DESCRIPTION
Fix code coverage accuracy by:

- starting Coverage at the correct point (before app imports)
- excluding the `tests` sub-modules for modular components in `app`