### PR TITLE
Remove extra jsonify calls

### DIFF
--- a/app/display_modules/macrobes/wrangler.py
+++ b/app/display_modules/macrobes/wrangler.py
@@ -4,7 +4,7 @@ from celery import chain
 from pandas import DataFrame
 
 from app.display_modules.display_wrangler import DisplayModuleWrangler
-from app.display_modules.utils import jsonify, persist_result_helper
+from app.display_modules.utils import persist_result_helper
 from app.extensions import celery
 from app.tool_results.macrobes import MacrobeResultModule
 
@@ -40,7 +40,7 @@ class MacrobeWrangler(DisplayModuleWrangler):
     @classmethod
     def run_sample(cls, sample_id, sample):
         """Gather single sample and process."""
-        samples = [jsonify(sample)]
+        samples = [sample]
         collate_task = collate_macrobes.s(samples)
         persist_task = persist_result.s(sample['analysis_result'], MODULE_NAME)
 

--- a/app/display_modules/pathways/wrangler.py
+++ b/app/display_modules/pathways/wrangler.py
@@ -3,7 +3,6 @@
 from celery import chain
 
 from app.display_modules.display_wrangler import DisplayModuleWrangler
-from app.display_modules.utils import jsonify
 
 from .constants import MODULE_NAME
 from .tasks import filter_humann2_pathways, persist_result
@@ -15,7 +14,7 @@ class PathwayWrangler(DisplayModuleWrangler):
     @classmethod
     def run_sample(cls, sample_id, sample):
         """Gather single sample and process."""
-        samples = [jsonify(sample)]
+        samples = [sample]
         persist_task = persist_result.s(sample['analysis_result'], MODULE_NAME)
         task_chain = chain(filter_humann2_pathways.s(samples),
                            persist_task)


### PR DESCRIPTION
To fix:

```
metagenscope-service    | --------------------------------------------------------------------------------
metagenscope-service    | ERROR in samples [/usr/src/app/app/api/v1/samples.py:139]:
metagenscope-service    | Exception while coordinating display modules.
metagenscope-service    | --------------------------------------------------------------------------------
metagenscope-service    | Traceback (most recent call last):
metagenscope-service    |   File "/usr/src/app/app/api/v1/samples.py", line 137, in run_sample_display_modules
metagenscope-service    |     downstream_groups=False).shake_that_baton()
metagenscope-service    |   File "/usr/src/app/app/display_modules/conductor.py", line 140, in shake_that_baton
metagenscope-service    |     self.direct_sample(sample)
metagenscope-service    |   File "/usr/src/app/app/display_modules/conductor.py", line 135, in direct_sample
metagenscope-service    |     module.get_wrangler().help_run_sample(sample=sample, module=module)
metagenscope-service    |   File "/usr/src/app/app/display_modules/display_wrangler.py", line 18, in help_run_sample
metagenscope-service    |     return cls.run_sample(sample.uuid, safe_sample)
metagenscope-service    |   File "/usr/src/app/app/display_modules/macrobes/wrangler.py", line 43, in run_sample
metagenscope-service    |     samples = [jsonify(sample)]
metagenscope-service    |   File "/usr/src/app/app/display_modules/utils.py", line 30, in jsonify
metagenscope-service    |     result_dict = mongo_doc.to_mongo().to_dict()
metagenscope-service    | AttributeError: 'dict' object has no attribute 'to_mongo'
metagenscope-service    | --------------------------------------------------------------------------------
metagenscope-service    | ERROR in samples [/usr/src/app/app/api/v1/samples.py:139]:
metagenscope-service    | Exception while coordinating display modules.
metagenscope-service    | --------------------------------------------------------------------------------
metagenscope-service    | Traceback (most recent call last):
metagenscope-service    |   File "/usr/src/app/app/api/v1/samples.py", line 137, in run_sample_display_modules
metagenscope-service    |     downstream_groups=False).shake_that_baton()
metagenscope-service    |   File "/usr/src/app/app/display_modules/conductor.py", line 140, in shake_that_baton
metagenscope-service    |     self.direct_sample(sample)
metagenscope-service    |   File "/usr/src/app/app/display_modules/conductor.py", line 135, in direct_sample
metagenscope-service    |     module.get_wrangler().help_run_sample(sample=sample, module=module)
metagenscope-service    |   File "/usr/src/app/app/display_modules/display_wrangler.py", line 18, in help_run_sample
metagenscope-service    |     return cls.run_sample(sample.uuid, safe_sample)
metagenscope-service    |   File "/usr/src/app/app/display_modules/methyls/wrangler.py", line 27, in run_sample
metagenscope-service    |     methyl_result = cls.help_run_generic_sample(sample, TOP_N, persist_result)
metagenscope-service    |   File "/usr/src/app/app/display_modules/generic_gene_set/wrangler.py", line 23, in help_run_generic_sample
metagenscope-service    |     persist_signature = persist_task.s(sample.analysis_result.pk,
metagenscope-service    | AttributeError: 'dict' object has no attribute 'analysis_result'
```