### PR TITLE
Fix gene set sample endpoint

### DIFF
--- a/app/display_modules/generic_gene_set/wrangler.py
+++ b/app/display_modules/generic_gene_set/wrangler.py
@@ -20,7 +20,7 @@ class GenericGeneWrangler(DisplayModuleWrangler):
         filter_task = filter_gene_results.s(samples,
                                             cls.tool_result_name,
                                             top_n)
-        persist_signature = persist_task.s(sample.analysis_result.pk,
+        persist_signature = persist_task.s(sample['analysis_result'],
                                            cls.result_name)
         task_chain = chain(filter_task, persist_signature)
         result = task_chain.delay()


### PR DESCRIPTION
Addresses:

```
metagenscope-service    | Traceback (most recent call last):
metagenscope-service    |   File "/usr/src/app/app/api/v1/samples.py", line 137, in run_sample_display_modules
metagenscope-service    |     downstream_groups=False).shake_that_baton()
metagenscope-service    |   File "/usr/src/app/app/display_modules/conductor.py", line 140, in shake_that_baton
metagenscope-service    |     self.direct_sample(sample)
metagenscope-service    |   File "/usr/src/app/app/display_modules/conductor.py", line 135, in direct_sample
metagenscope-service    |     module.get_wrangler().help_run_sample(sample=sample, module=module)
metagenscope-service    |   File "/usr/src/app/app/display_modules/display_wrangler.py", line 18, in help_run_sample
metagenscope-service    |     return cls.run_sample(sample.uuid, safe_sample)
metagenscope-service    |   File "/usr/src/app/app/display_modules/methyls/wrangler.py", line 27, in run_sample
metagenscope-service    |     methyl_result = cls.help_run_generic_sample(sample, TOP_N, persist_result)
metagenscope-service    |   File "/usr/src/app/app/display_modules/generic_gene_set/wrangler.py", line 23, in help_run_generic_sample
metagenscope-service    |     persist_signature = persist_task.s(sample.analysis_result.pk,
metagenscope-service    | AttributeError: 'dict' object has no attribute 'analysis_result'
```