### PR TITLE
Skip returning the metadata when fetching a sample

### DIFF
--- a/app/api/v1/samples.py
+++ b/app/api/v1/samples.py
@@ -67,7 +67,8 @@ def get_single_sample(sample_uuid):
     try:
         uuid = UUID(sample_uuid)
         sample = Sample.objects.get(uuid=uuid)
-        result = SampleSchema(only=('uuid', 'name')).dump(sample).data
+        fields = ('uuid', 'name', 'analysis_result_uuid', 'created_at')
+        result = SampleSchema(only=fields).dump(sample).data
         return result, 200
     except ValueError:
         raise ParseError('Invalid UUID provided.')

--- a/tests/apiv1/test_samples.py
+++ b/tests/apiv1/test_samples.py
@@ -72,7 +72,6 @@ class TestSampleModule(BaseTestCase):
             self.assertIn('success', data['status'])
             sample = data['data']['sample']
             self.assertIn('SMPL_01', sample['name'])
-            self.assertIn('metadata', sample)
             self.assertIn('analysis_result_uuid', sample)
             self.assertIn('created_at', sample)
 


### PR DESCRIPTION
To address the single-sample pages returning:

```
Error: TypeError: undefined is not an object (evaluating 'res.data.data.sample')
```