### PR TITLE
Fix empty top taxa values

### DIFF
--- a/analysis_packages/top_taxa/analysis.py
+++ b/analysis_packages/top_taxa/analysis.py
@@ -25,6 +25,7 @@ def filter_to_species_and_normalize(taxa_vec):
         out = {'unknown': 1}
     return out
 
+
 def taxa_in_kingdom(sample, tool_name, kingdom):
     """Return taxa in the given kingdom."""
     if kingdom == 'all_kingdoms':


### PR DESCRIPTION
Explicitly specify that nothing was found if a tool did not find any taxa.